### PR TITLE
correction to README. systemctl --user will not work with sudo

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,5 +24,5 @@ sudo cp headsetcontrol-notificationd /usr/local/bin/headsetcontrol-notificationd
 sudo chmod +x /usr/local/bin/headsetcontrol-notificationd
 
 sudo systemctl daemon-reload
-sudo systemctl --user enable --now headsetcontrol-notificationd
+systemctl --user enable --now headsetcontrol-notificationd
 ```


### PR DESCRIPTION
since the systemd unit is stored inside /etc/systemd/user when enabling the service you can't use sudo, because the service will not run as root.